### PR TITLE
fix(clafrica): previous out not always write back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correct logic of writing back of the previous out after backspace
+
 ## [0.2.1] - 2023-05-15
 
 ### Added
@@ -23,14 +27,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Implement the initial binary application
-- (lib) Implement a cursor
+- Implement the initial binary application (#8)
+- (lib) Implement a cursor (#6)
 - (lib) Each node hold his key (#16)
-- (lib) Each node hold his depth on the tree
+- (lib) Each node hold his depth on the tree (#5)
 
 ### Changed
 
-- (lib) Rename bst to text_buffer
+- (lib) Rename bst to text_buffer (#9)
 
 ## [0.1.1] - 2023-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Correct logic of writing back of the previous out after backspace
+- Correct logic of writing back of the previous out after backspace (#39)
 
 ## [0.2.1] - 2023-05-15
 

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -59,16 +59,16 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
                     let i = out.chars().count();
                     (1..i).for_each(|_| keyboard.key_click(Key::Backspace));
 
-                    if let (Some(prev_out), ..) = cursor.state() {
-                        keyboard.key_sequence(&prev_out);
-                    }
-
                     rdev::simulate(&EventType::KeyRelease(E_Key::Pause))
                         .expect("We could resume the listeners");
 
                     // Clear the remaining code
                     while let (None, _i @ 1.., ..) = cursor.state() {
                         cursor.undo();
+                    }
+
+                    if let (Some(prev_out), ..) = cursor.state() {
+                        keyboard.key_sequence(&prev_out);
                     }
                 }
 


### PR DESCRIPTION
The previous out was not write back when the output was not aligned. eg. None, Some, None, None, Some
The problem was that the logic was not in a good place.