### PR TITLE
feat(clafrica): implement pause/resume the clafrica

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
+### Added
+- Add a pause/resume way via double pressing of CTRL key [(#49)](https://github.com/pythonbrad/clafrica/pull/49)
 
+### Fixed
 - (lib) Problem of endless sequence  [(#44)](https://github.com/pythonbrad/clafrica/pull/44)
 - Correct problem of excessive backspace [(#43)](https://github.com/pythonbrad/clafrica/pull/43)
 - The Capslock key don't reset the cursor [(#45)](https://github.com/pythonbrad/clafrica/pull/45)

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -34,7 +34,8 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
             idle = match event.event_type {
                 EventType::KeyPress(E_Key::Pause) => true,
                 EventType::KeyRelease(E_Key::Pause) => false,
-                EventType::KeyRelease(E_Key::ControlLeft) | EventType::KeyPress(E_Key::ControlLeft) => {
+                EventType::KeyRelease(E_Key::ControlLeft)
+                | EventType::KeyPress(E_Key::ControlLeft) => {
                     pause_counter += 1;
 
                     if pause_counter != 0 && pause_counter % 4 == 0 {
@@ -43,11 +44,11 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
                     } else {
                         idle
                     }
-                },
+                }
                 _ => {
                     pause_counter = 0;
                     idle
-                },
+                }
             };
             if !idle {
                 tx.send(event)


### PR DESCRIPTION
resolve #48

Now, the user can switch between the clafrica mode and the normal mode in double pressing the CTRL key.