### PR TITLE
fix(clafrica): implement pause/resume the clafrica (completion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Add a pause/resume way via double pressing of CTRL key [(#49)](https://github.com/pythonbrad/clafrica/pull/49)
+- Add a pause/resume way via double pressing of CTRL key [(#50)](https://github.com/pythonbrad/clafrica/pull/50) & [(#49)](https://github.com/pythonbrad/clafrica/pull/49)
 
 ### Fixed
 - (lib) Problem of endless sequence  [(#44)](https://github.com/pythonbrad/clafrica/pull/44)

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -34,8 +34,8 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
             idle = match event.event_type {
                 EventType::KeyPress(E_Key::Pause) => true,
                 EventType::KeyRelease(E_Key::Pause) => false,
-                EventType::KeyRelease(E_Key::ControlLeft)
-                | EventType::KeyPress(E_Key::ControlLeft) => {
+                EventType::KeyRelease(E_Key::ControlLeft | E_Key::ControlRight)
+                | EventType::KeyPress(E_Key::ControlLeft | E_Key::ControlRight) => {
                     pause_counter += 1;
 
                     if pause_counter != 0 && pause_counter % 4 == 0 {


### PR DESCRIPTION
resolve #48 

Now, CTRL Left and CTRL Right are supported