### PR TITLE
feat(clafrica): implement auto capitalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+- Implement the auto capitalization. [(#56)](https://github.com/pythonbrad/clafrica/pull/56)
+
+### Fixed
 - Improve the pause/resume way via double pressing of CTRL key. [(#54)](https://github.com/pythonbrad/clafrica/pull/54)
 
 ## [0.3.0] - 2023-06-02

--- a/clafrica/data/config_sample.toml
+++ b/clafrica/data/config_sample.toml
@@ -2,6 +2,7 @@
 
 [core]
 buffer_size = 12
+auto_capitalize = false
 
 [data]
 sample = { path = "./data_sample.toml" }

--- a/clafrica/data/test.toml
+++ b/clafrica/data/test.toml
@@ -6,10 +6,12 @@ description = "Test code for testing purpose."
 
 [core]
 buffer_size = 128
+auto_capitalize = true
 
 [data]
 af       =   "ɑ"
-af3      =   "ɑ̄"
+Af       =   "α"
+u5       =   { value = "û", alias = ["5u"]}
 aff      =   "ɑɑ"
 aff3     =   "ɑ̄ɑ̄"
 cc       =   { value = "ç", alias = ["ccced"]}

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -15,7 +15,7 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
     let map = utils::build_map(
         config
             .extract_data()
-            .into_iter()
+            .iter()
             .map(|(k, v)| [k.as_str(), v.as_str()])
             .collect(),
     );
@@ -265,6 +265,32 @@ mod tests {
         input!(KeyA KeyF, typing_speed_ms);
 
         output!(textfield, format!("{LIMIT}afɑ"));
+
+        (0..3).for_each(|_| {
+            input!(Backspace, typing_speed_ms);
+        });
+
+        input!(CapsLock, typing_speed_ms);
+        input!(KeyA, typing_speed_ms);
+        input!(CapsLock, typing_speed_ms);
+
+        input!(KeyF, typing_speed_ms);
+
+        input!(CapsLock, typing_speed_ms);
+        input!(KeyU, typing_speed_ms);
+        input!(CapsLock, typing_speed_ms);
+
+        input!(CapsLock, typing_speed_ms);
+        input!(Num5, typing_speed_ms);
+        input!(CapsLock, typing_speed_ms);
+
+        input!(CapsLock, typing_speed_ms);
+        input!(Num5, typing_speed_ms);
+        input!(CapsLock, typing_speed_ms);
+
+        input!(KeyU, typing_speed_ms);
+
+        output!(textfield, format!("{LIMIT}αÛû"));
 
         rstk::end_wish();
     }

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -253,26 +253,11 @@ mod tests {
             input!(Backspace, typing_speed_ms);
         });
 
-        input!(CapsLock, typing_speed_ms);
-        input!(KeyA, typing_speed_ms);
-        input!(CapsLock, typing_speed_ms);
-
-        input!(KeyF, typing_speed_ms);
-
-        input!(CapsLock, typing_speed_ms);
-        input!(KeyU, typing_speed_ms);
-        input!(CapsLock, typing_speed_ms);
-
-        input!(CapsLock, typing_speed_ms);
-        input!(Num5, typing_speed_ms);
-        input!(CapsLock, typing_speed_ms);
-
-        input!(CapsLock, typing_speed_ms);
-        input!(Num5, typing_speed_ms);
-        input!(CapsLock, typing_speed_ms);
-
-        input!(KeyU, typing_speed_ms);
-
+        // We verify the auto capitalization works as expected
+        input!(CapsLock KeyA CapsLock KeyF, typing_speed_ms);
+        input!(CapsLock KeyU CapsLock, typing_speed_ms);
+        input!(CapsLock Num5 CapsLock, typing_speed_ms);
+        input!(CapsLock Num5 CapsLock KeyU, typing_speed_ms);
         output!(textfield, format!("{LIMIT}αÛû"));
 
         rstk::end_wish();


### PR DESCRIPTION
Now, when a code begin by a capital letter, the output will be capitalized. And to overwrite the default capitalization, the user can provide his own.