### PR TITLE
chore(clafrica): Remove function keys F1-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Improve the pause/resume way via double pressing of CTRL key. [(#54)](https://github.com/pythonbrad/clafrica/pull/54)
+- Drop function key F1-12 which was reserved for special purposes. [(#62)](https://github.com/pythonbrad/clafrica/pull/62)
 
 ## [0.3.0] - 2023-06-02
 

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -90,10 +90,7 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
                 frontend.update_text(cursor.to_sequence());
             }
             EventType::KeyPress(
-                E_Key::Unknown(_) | E_Key::ShiftLeft | E_Key::ShiftRight | E_Key::CapsLock |
-                // Reserved for special purpose
-                E_Key::F1 | E_Key::F2 | E_Key::F3 | E_Key::F4 | E_Key::F5 | E_Key::F6 |
-                E_Key::F7 | E_Key::F8 | E_Key::F9 | E_Key::F10 | E_Key::F11 | E_Key::F12
+                E_Key::Unknown(_) | E_Key::ShiftLeft | E_Key::ShiftRight | E_Key::CapsLock,
             ) => {
                 // println!("[ignore] {:?}", event.event_type)
             }
@@ -108,7 +105,7 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
 
                 if let Some(_in) = cursor.hit(character) {
                     rdev::simulate(&EventType::KeyPress(E_Key::Pause))
-                        .expect("We could pause the listenerss");
+                        .expect("We could pause the listeners");
 
                     keyboard.key_click(Key::Backspace);
 


### PR DESCRIPTION
The objective was to reserve these keys for a special purpose.
However, these keys are already being used by some programs.
Which can result in conflicts with our input method.