### PR TITLE
revert(clafrica): whitespaces as allowed chacracters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement the auto capitalization. [(#56)](https://github.com/pythonbrad/clafrica/pull/56)
 
 ### Fixed
-- Allowed whitespaces usage. [(#63)](https://github.com/pythonbrad/clafrica/pull/63)
 - Improve the pause/resume way via double pressing of CTRL key. [(#54)](https://github.com/pythonbrad/clafrica/pull/54)
 - Drop function key F1-12 which was reserved for special purposes. [(#62)](https://github.com/pythonbrad/clafrica/pull/62)
 

--- a/clafrica/data/test.toml
+++ b/clafrica/data/test.toml
@@ -18,4 +18,3 @@ cc       =   { value = "ç", alias = ["ccced"]}
 uu       =   "ʉ"
 uu3      =   "ʉ̄"
 uuaf3    =   "ʉ̄ɑ̄"
-"a\t"    =   "ɑ"

--- a/clafrica/src/lib.rs
+++ b/clafrica/src/lib.rs
@@ -61,8 +61,8 @@ pub fn run(config: config::Config, mut frontend: impl Frontend) -> Result<(), io
     for event in rx.iter() {
         let character = event.name.and_then(|s| s.chars().next());
         let is_valid = character
-            .map(|c| c.is_alphanumeric() || c.is_ascii_punctuation() || c.is_whitespace())
-            .unwrap_or(false);
+            .map(|c| c.is_alphanumeric() || c.is_ascii_punctuation())
+            .unwrap_or_default();
 
         match event.event_type {
             EventType::KeyPress(E_Key::Backspace) => {
@@ -256,10 +256,6 @@ mod tests {
         input!(CapsLock Num5 CapsLock, typing_speed_ms);
         input!(CapsLock Num5 CapsLock KeyU, typing_speed_ms);
         output!(textfield, format!("{LIMIT}αÛû"));
-
-        // We verify that the usage of white works as expected
-        input!(KeyA Tab, typing_speed_ms);
-        output!(textfield, format!("{LIMIT}αÛûɑ"));
 
         rstk::end_wish();
     }


### PR DESCRIPTION
Undo #61

## Problem
#61 wasn't a bad idea, but it's better for us to stay with the management of words.
The white-spaces often result in breaking depending of the text area.
And it will not easy to manage the previous transformation in the buffer.