### PR TITLE
feat(clafrica): auto_capitalize by configuration file

### DIFF
--- a/clafrica/data/data_sample.toml
+++ b/clafrica/data/data_sample.toml
@@ -9,6 +9,9 @@ authors = [
 website = "sample@example.com"
 description = "Sample code for testing purpose."
 
+[core]
+auto_capitalize = true
+
 [data]
 2a_		   =	 "á̠"
 2af_	   =	 "ɑ̠́"
@@ -19,4 +22,6 @@ description = "Sample code for testing purpose."
 2ua		   =	 "úá"
 2uaf	   =	 "úɑ́"
 2uuaf	   =	 "ʉ́ɑ́"
+u2	=	"ú"
+a2	=	"á"
 sample2  =   { path = "./data_sample2.toml" }

--- a/clafrica/data/data_sample2.toml
+++ b/clafrica/data/data_sample2.toml
@@ -6,6 +6,9 @@ authors = ["Foo Bar <foo@example.com>"]
 website = "sample@example.com"
 description = "Sample code for testing purpose."
 
+[core]
+auto_capitalize = false
+
 [data]
 2aa		=	 { value = "áá", alias = ["a22"]}
 2ee		=	 { value = "éé", alias = ["e22"]}


### PR DESCRIPTION
Often, some configuration file include data who don't require
auto_capitalization. It's now possible to overwrite the default
configuration.